### PR TITLE
FIX | shutdown on reboot

### DIFF
--- a/src/walletHooks/component/ButtonConnect/connectButton.tsx
+++ b/src/walletHooks/component/ButtonConnect/connectButton.tsx
@@ -80,7 +80,7 @@ export const ConnectButton = ({
   const copyTextRef = useRef(null);
 
   useEffect(() => {
-    window.localStorage.clear();
+    // window.localStorage.clear();
   }, [setProvider]);
 
   return (
@@ -124,7 +124,10 @@ export const ConnectButton = ({
                   supportedConnectors?.includes(connector.name)
                 )
                 .map((connector) => (
-                  <ConnectorsItem className="modalConnectorsItem">
+                  <ConnectorsItem
+                    className="modalConnectorsItem"
+                    key={connector.name}
+                  >
                     <BtnConnector
                       onClick={() => setProvider(connector.provider)}
                       className="modalBtnProvider"

--- a/src/walletHooks/component/hooks/useBtnConnect.tsx
+++ b/src/walletHooks/component/hooks/useBtnConnect.tsx
@@ -30,7 +30,8 @@ export const useBtnConnect = () => {
   const disconnect = () => {
     refreshState();
     deactivate();
-    localStorage.clear();
+    // localStorage.clear();
+    window.localStorage.clear();
   };
 
   useEffect(() => {


### PR DESCRIPTION
fixed a bug - when reloading the page, the connector was deleted from localStorage